### PR TITLE
making the library multithread safe

### DIFF
--- a/tiny_jpeg.h
+++ b/tiny_jpeg.h
@@ -206,8 +206,10 @@ static uint8_t tjei_g_output_buffer[TJEI_BUFFER_SIZE];
 
 #ifdef _WIN32
 #define tje_log(msg) OutputDebugStringA(msg)
-#elif defined(__linux__) || defined(__MACH__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define tje_log(msg) puts(msg)
+#else
+#warning "need a tje_log definition for your platform for debugging purposes (not needed if compiling with NDEBUG)"
 #endif
 
 #else  // NDEBUG


### PR DESCRIPTION
Dear Serge,

Thanks for the library, I appreciate the small one header library. I really like it. Because I use the library in a multithreaded program on FreeBSD I made some necessary changes. The library can now compile correctly on FreeBSD. The global buffer is removed and added to the state so no race conditions occur. Will you consider importing these changes into master? I more changes are necessary, I would like to help.

Thanks in advance,
  Bernard van Gastel