### PR TITLE
Remove warning on Visual Studio

### DIFF
--- a/tiny_jpeg.h
+++ b/tiny_jpeg.h
@@ -76,7 +76,9 @@ int main()
 
 */
 
-
+#if defined(_MSC_VER) && (_MSC_VER >= 1310) /*Visual Studio: A few warning types are not desired here.*/
+#pragma warning( disable : 4996 ) /*VS does not like fopen, but fopen_s is not standard C so unusable here*/
+#endif /*_MSC_VER */
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Tested on Visual Studio 2015, should work on 2012, 2013, 2017 and maybe even more.

Visual Studio refuse to compile due to the use of fopen().
This pragma disable the warning and let the compilation proceed.

I took the code from LodePNG https://github.com/lvandeve/lodepng/blob/master/lodepng.cpp#L37-L40
That's not a very important PR but may be useful to somes !

Thanks.