### PR TITLE
Added math library linking instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,12 @@ Features:
     - 3-value compression quality: 3 (best quality), 2 (Very good), 1 (Noticeable artifacts, best compression)
 - Public domain
 
+- On some systems, you may have an error:
+
+``/usr/local/bin/ld: main.o: in function tjei_encode_and_write_MCU':
+main.c:(.text+0xeb8): undefined reference to floorf'``
+
+To fix it, you may have to link the math library
+
+``gcc -o bayer_img.elf pipeline.o main.o -lm``
 

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ main.c:(.text+0xeb8): undefined reference to floorf'``
 
 To fix it, you may have to link the math library
 
-``gcc -o bayer_img.elf pipeline.o main.o -lm``
+``gcc -o <OUTPUT_EXE> pipeline.o main.o -lm``
 


### PR DESCRIPTION
In some systems, compiling normally may lead to issues involving something called **floorf**. This issue stems from some systems needing to link against the math library, which is something I noted in README.md.